### PR TITLE
fix:add-necessary-permissions-for-aws-alb-ingress-controller-sa-role

### DIFF
--- a/aws-load-balancer-controller.tf
+++ b/aws-load-balancer-controller.tf
@@ -79,6 +79,7 @@ locals {
                     "elasticloadbalancing:DescribeLoadBalancers",
                     "elasticloadbalancing:DescribeLoadBalancerAttributes",
                     "elasticloadbalancing:DescribeListeners",
+                    "elasticloadbalancing:DescribeListenerAttributes",
                     "elasticloadbalancing:DescribeListenerCertificates",
                     "elasticloadbalancing:DescribeSSLPolicies",
                     "elasticloadbalancing:DescribeRules",


### PR DESCRIPTION
## WHY?
#### AWS Load Balancer Controller lacks the necessary permissions to perform the `elasticloadbalancing:DescribeListenerAttributes` action:
![Screenshot 2025-03-26 at 15 47 08](https://github.com/user-attachments/assets/ea4548c6-0bc2-4995-b07b-61c8191d7c20)

![Screenshot 2025-03-26 at 15 47 24](https://github.com/user-attachments/assets/dfb4d6cd-374e-4eae-ab8f-ef53b220e60f)
### How was fixed?
Added missed permissions 
`elasticloadbalancing:DescribeListenerAttributes`

### How was it tested?
![image](https://github.com/user-attachments/assets/e68647eb-0fe7-40e5-a504-284a62157d6f)

