### PR TITLE
Update iam allow actions aws-load-balancer-controller

### DIFF
--- a/aws-load-balancer-controller.tf
+++ b/aws-load-balancer-controller.tf
@@ -63,6 +63,7 @@ locals {
             {
                 "Effect": "Allow",
                 "Action": [
+                    "ec2:GetSecurityGroupsForVpc",
                     "ec2:DescribeAccountAttributes",
                     "ec2:DescribeAddresses",
                     "ec2:DescribeAvailabilityZones",


### PR DESCRIPTION
Error that I got: 
```
{"level":"error","ts":"2025-05-21T14:28:46Z","msg":"Reconciler error","controller":"ingress","object":{"name":"internal"},"namespace":"","name":"internal","reconcileID":"xxxx","error":"operation error Elastic Load Balancing v2: CreateLoadBalancer, https response error StatusCode: 403, RequestID: , api error AccessDenied: User: arn:aws:sts::x:xxxassumed-role/xxxxx-aws-alb-ingress-controller-iam-role/xxxx is not authorized to perform: ec2:GetSecurityGroupsForVpc"}
```