### PR TITLE
Helm version changes

### DIFF
--- a/examples/eks.tf
+++ b/examples/eks.tf
@@ -36,7 +36,7 @@ provider "kubernetes" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = module.eks.cluster_endpoint
     cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
     token                  = data.aws_eks_cluster_auth.this.token

--- a/examples/secure-eks/eks.tf
+++ b/examples/secure-eks/eks.tf
@@ -31,16 +31,18 @@ provider "kubernetes" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = module.eks.cluster_endpoint
     cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
     token                  = data.aws_eks_cluster_auth.this.token
   }
-  registry {
-    url      = "oci://public.ecr.aws"
-    username = data.aws_ecrpublic_authorization_token.token.user_name
-    password = data.aws_ecrpublic_authorization_token.token.password
-  }
+  registries = [ 
+    {
+      url      = "oci://public.ecr.aws"
+      username = data.aws_ecrpublic_authorization_token.token.user_name
+      password = data.aws_ecrpublic_authorization_token.token.password
+    }
+  ]
 }
 
 provider "kubectl" {

--- a/versions.tf
+++ b/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.9.0"
+      version = ">= 3.0.0"
     }
     kubectl = {
       source  = "alekc/kubectl"


### PR DESCRIPTION
One of the [latest](https://registry.terraform.io/providers/hashicorp/helm/3.0.0/docs) helm provider version changed syntax a bit. Example files were adapted to meet new requirements.