### PR TITLE
README: add another preparation step to init Karpenter smoothly

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ For Karpenter installation, please log out of the Amazon ECR Public registry bef
 
 ```shell
 helm registry logout public.ecr.aws
+docker logout public.ecr.aws
 ```
 
 You can check why these steps are necessary in [AWS Doc](https://docs.aws.amazon.com/AmazonECR/latest/public/public-troubleshooting.html#public-troubleshooting-authentication), [Karpenter official manual](https://karpenter.sh/docs/getting-started/getting-started-with-karpenter/#4-install-karpenter), [Karpenter troubleshooting](https://karpenter.sh/docs/troubleshooting/#missing-service-linked-role)


### PR DESCRIPTION
for me:
- no previous use of this TF module or Karpenter;
- the TF module is added, but `tf plan` hangs forever. once stopped, the following error appears:

<img width="1148" alt="Screenshot 2025-06-27 at 18 49 32" src="https://github.com/user-attachments/assets/91cdbfaf-b5e4-4779-839b-c042bba898ff" />

the command from the suggestion fixed the issue.