### PR TITLE
README: specify explicitly the only tested src for the `kubectl` TF provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ helm registry logout public.ecr.aws
 
 You can check why these steps are necessary in [AWS Doc](https://docs.aws.amazon.com/AmazonECR/latest/public/public-troubleshooting.html#public-troubleshooting-authentication), [Karpenter official manual](https://karpenter.sh/docs/getting-started/getting-started-with-karpenter/#4-install-karpenter), [Karpenter troubleshooting](https://karpenter.sh/docs/troubleshooting/#missing-service-linked-role)
 
+`"alekc/kubectl"` is the only tested source for the `kubectl` TF provider.
+
 ### Karpenter CRD migration
 
 In v1.31.2 karpenter crd installation as separate helm chart was introduced. It was done to handle crd update issue in karpenter future karpenter updates.


### PR DESCRIPTION
the suggestion is to focus attention on the only tested source of the `kubectl` TF provider.

another source was in use for our EKS cluster, initially.

was working fine for all EKS resources, as well as for most resources of the Karpenter TF module.
but the `resource "kubectl_manifest" "karpenter_default_node_class"` creation was failing:

<img width="1349" alt="Screenshot 2025-07-01 at 19 23 20" src="https://github.com/user-attachments/assets/7b26f37d-abac-4087-8936-1c99078a0c25" />

at that moment:
- the correct Karpenter CRD was already present;
- the expected Karpenter API was already present;
- the manual creation (`k apply -f ...`) of the same  `kubectl_manifest.karpenter_default_node_class` resource (taken from the `tf plan` output) was successful.

moving source of the `kubectl` TF provider from the old `"gavinbunney/kubectl"` to the expected `"alekc/kubectl"` fixed the issue.


