### PR TITLE
fix: add DescribeRouteTables permission for ALB Controller

### DIFF
--- a/aws-load-balancer-controller.tf
+++ b/aws-load-balancer-controller.tf
@@ -70,6 +70,7 @@ locals {
                     "ec2:DescribeInternetGateways",
                     "ec2:DescribeVpcs",
                     "ec2:DescribeVpcPeeringConnections",
+                    "ec2:DescribeRouteTables",
                     "ec2:DescribeSubnets",
                     "ec2:DescribeSecurityGroups",
                     "ec2:DescribeInstances",


### PR DESCRIPTION
Encountered error like this:
`
Warning  FailedBuildModel  73s (x8 over 5m13s)  ingress  (combined from similar events): Failed build model due to couldn't auto-discover subnets: failed to list subnets by reachability: operation error EC2: DescribeRouteTables, https response error StatusCode: 403, RequestID: 35a4b942-2d20-4b9f-8418-3584e8562055, api error UnauthorizedOperation: You are not authorized to perform this operation. User: arn:aws:sts::**accountId**:assumed-role/EKS-Picafuel-Dev-aws-alb-ingress-controller-iam-role/1752244163198006750 is not authorized to perform: ec2:DescribeRouteTables because no identity-based policy allows the ec2:DescribeRouteTables action
`
when deploying ALB Ingress:
```
resource "kubectl_manifest" "fake_ingress" {
  yaml_body  = <<-YAML
    apiVersion: networking.k8s.io/v1
    kind: Ingress
    metadata:
      name: picafuel-dev-ingress
      namespace: monitoring
      annotations:
        alb.ingress.kubernetes.io/group.name: picafuel-dev
        alb.ingress.kubernetes.io/actions.fixed-response: >
          {"type":"fixed-response","fixedResponseConfig":{"statusCode":"200","contentType":"text/plain","messageBody":"OK"}}
        alb.ingress.kubernetes.io/scheme: internal
        alb.ingress.kubernetes.io/target-type: instance
        alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80},{"HTTPS":443}]'
        alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:ap-southeast-2:**accountId**:certificate/ed087231-8d4a-4a3b-bbf7-baf1846d696a
    spec:
      ingressClassName: alb
      defaultBackend:
        service:
          name: fixed-response
          port:
            name: use-annotation
  YAML
  depends_on = [module.eks-aux]
}
```