### PR TITLE
Update nodeclass parameters

### DIFF
--- a/karpenter.tf
+++ b/karpenter.tf
@@ -57,6 +57,15 @@ locals {
     metadata:
       name: ${var.services.karpenter.default_nodeclass_name}
     spec:
+    %{~if coalesce(var.services.karpenter.default_nodeclass_max_pods, "default") != "default" || coalesce(var.services.karpenter.default_nodeclass_pods_per_core, "default") != "default"~}
+      kubelet:
+        %{~if coalesce(var.services.karpenter.default_nodeclass_pods_per_core, "default") != "default"~}
+        podsPerCore: ${var.services.karpenter.default_nodeclass_pods_per_core}
+        %{~endif~}
+        %{~if coalesce(var.services.karpenter.default_nodeclass_max_pods, "default") != "default"~}
+        maxPods: ${var.services.karpenter.default_nodeclass_max_pods}
+        %{~endif~}
+    %{~endif~}
     %{~if coalesce(var.services.karpenter.default_nodeclass_ami_family, "no_nodeclass") != "no_nodeclass"~}
       amiFamily: ${var.services.karpenter.default_nodeclass_ami_family}
     %{~endif~}
@@ -94,8 +103,8 @@ locals {
 ))}
   YAML
 
-# Default karpenter nodepool
-default_nodepool_yaml = !var.services.karpenter.enabled ? "" : <<-YAML
+  # Default karpenter nodepool
+  default_nodepool_yaml = !var.services.karpenter.enabled ? "" : <<-YAML
     apiVersion: karpenter.sh/v1
     kind: NodePool
     metadata:

--- a/variables.tf
+++ b/variables.tf
@@ -193,6 +193,8 @@ variable "services" {
       additional_helm_values              = optional(string, "")
       crd_additional_helm_values          = optional(string, "")
       deploy_default_nodeclass            = optional(bool, true)
+      default_nodeclass_max_pods          = optional(string)
+      default_nodeclass_pods_per_core     = optional(string)
       default_nodeclass_ami_family        = optional(string, "AL2023")
       default_nodeclass_ami_alias         = optional(string, "al2023@latest")
       default_nodeclass_name              = optional(string, "default")


### PR DESCRIPTION
🚀 Changes in this PR

1. Added new Karpenter NodeClass parameters:
   - default_nodeclass_max_pods
   - default_nodeclass_pods_per_core

2. Updated karpenter.tf to support new kubelet settings:
   - podsPerCore
   - maxPods

3. Extended variables in variables.tf for better configurability of node class behavior

🔴 Breaking Changes

- Default Karpenter behavior may change if max_pods or pods_per_core are explicitly set, as they now override kubelet defaults.
- Existing configurations without these variables are not affected, but introducing them will enforce stricter scheduling rules.

❗ Additional Notes

Tested with real project values to confirm backward compatibility when variables are unset.

✅ How was it tested?
- Applied changes in both Stage and Prod environments
- Verified NodeClass creation and kubelet settings through kubectl get nodeclass and logs
- Confirmed no disruption for existing workloads when variables are left unset